### PR TITLE
Support Post Image Captioning Using Alt

### DIFF
--- a/components/postImage.js
+++ b/components/postImage.js
@@ -3,7 +3,7 @@ export default function PostImage({ className, media }) {
 
   const img = (
     <img
-      className={className}
+      className={className + " m-0"}
       src={src}
       alt={alt}
       style={{ width: "75%", height: "auto" }}
@@ -13,14 +13,17 @@ export default function PostImage({ className, media }) {
   return (
     /* add div to have images centered */
     <div className="flex justify-center">
-      {/* add link to image if link exists */}
-      {href ? (
-        <a href={href} target="_blank" rel="noreferrer">
-          {img}
-        </a>
-      ) : (
-        img
-      )}
+      <div className="flex flex-col items-center">
+        {/* add link to image if link exists */}
+        {href ? (
+          <a href={href} target="_blank" rel="noreferrer">
+            {img}
+          </a>
+        ) : (
+          img
+        )}
+        <p className="mt-0">{alt}</p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Now if you add an alt to an image, it will automatically display as the image's caption. 
However, to set the alt in notion, you have to set the "caption" instead.